### PR TITLE
Update Gruntfile.js

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -176,13 +176,13 @@ module.exports = function (grunt) {
                         ]
 					},
 					{
-						dest: '<%%= yeoman.dist %>/styles/bootstrap.min.css',
+						dest: '<%%= yeoman.dist %>/styles/bootstrap/css/bootstrap.min.css',
 						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/css/bootstrap.min.css']
 					},
 					{
 						expand: true,
 						flatten: true,
-						dest: '<%%= yeoman.dist %>/fonts/',
+						dest: '<%%= yeoman.dist %>/styles/bootstrap/fonts/',
 						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/fonts/*']
 					}<% if (includeRespond || includeHtml5shiv) { %>,
                     {
@@ -203,14 +203,14 @@ module.exports = function (grunt) {
 			server: {
 				files: [
 					{
-						dest: '.tmp/styles/bootstrap.min.css',
+						dest: '.tmp/styles/bootstrap/css/bootstrap.min.css',
 						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/css/bootstrap.min.css']
 					},
 					{
 						expand: true,
 						flatten: true,
-						dest: '.tmp/fonts/',
-						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/fonts/*-']
+						dest: '.tmp/styles/bootstrap/fonts/',
+						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/fonts/*']
 					}<% if (includeFontAwesome) { %>,
 					{
 						expand: true,

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -178,6 +178,12 @@ module.exports = function (grunt) {
 					{
 						dest: '<%%= yeoman.dist %>/styles/bootstrap.min.css',
 						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/css/bootstrap.min.css']
+					},
+					{
+						expand: true,
+						flatten: true,
+						dest: '<%%= yeoman.dist %>/fonts/',
+						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/fonts/*']
 					}<% if (includeRespond || includeHtml5shiv) { %>,
                     {
                         expand: true,
@@ -199,6 +205,12 @@ module.exports = function (grunt) {
 					{
 						dest: '.tmp/styles/bootstrap.min.css',
 						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/css/bootstrap.min.css']
+					},
+					{
+						expand: true,
+						flatten: true,
+						dest: '.tmp/fonts/',
+						src: ['<%%= yeoman.app %>/bower_components/bootstrap/dist/fonts/*-']
 					}<% if (includeFontAwesome) { %>,
 					{
 						expand: true,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <link rel="icon" href="favicon.ico" type="image/x-icon" />
-		<link rel="stylesheet" href="styles/bootstrap.min.css"><% if (includeFontAwesome) { %>
+        <link rel="stylesheet" href="styles/bootstrap/css/bootstrap.min.css"><% if (includeFontAwesome) { %>
         <link rel="stylesheet" href="styles/font-awesome/css/font-awesome.min.css"><% } %>
         <!-- build:css(.tmp) styles/main.min.css -->
         <link rel="stylesheet" href="styles/main.css">
@@ -81,7 +81,7 @@
 
         </div>
 
-		<!-- build:js scripts/vendor.min.js -->
+        <!-- build:js scripts/vendor.min.js -->
         <script src="bower_components/jquery/dist/jquery.js"></script>
         <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script><% if (includeUnderscore) { %>
         <script src="bower_components/underscore/underscore.js"></script><% } %>


### PR DESCRIPTION
Include Bootstrap `fonts` directory in both `dist` and `.tmp` output.

This fixes the missing font error when using the built-in Bootstrap Glyphicons.
